### PR TITLE
feat(tmux): add prefix+s for new session and prefix+r for rename

### DIFF
--- a/home-manager/modules/tmux/tmux.conf
+++ b/home-manager/modules/tmux/tmux.conf
@@ -80,6 +80,10 @@ unbind o
 bind o display-popup -h 90% -w 90% -E "tmux-file-pick"
 bind a display-popup -h 20% -w 40% -E "tmux-aider-model"
 bind p choose-tree -s
+unbind s
+bind s new-session
+unbind r
+bind r display-popup -h 20% -w 40% -E "read -rp 'Session name: ' name && tmux rename-session \"$name\""
 
 # Pane toggle
 bind-key -n M-t select-pane -l


### PR DESCRIPTION
Adds two new tmux key bindings:

- `prefix + s` → new session
- `prefix + r` → rename session via popup

Closes #21

Generated with [Claude Code](https://claude.ai/code)